### PR TITLE
Update README.md

### DIFF
--- a/testnet-croeseid-2/README.md
+++ b/testnet-croeseid-2/README.md
@@ -60,6 +60,12 @@ INF Reset private validator file to genesis state keyFile=/Users/.chain-maind/co
   ```bash
   $ sed -i.bak -E 's#^(seeds[[:space:]]+=[[:space:]]+).*$#\1"b2c6657096aa30c5fafa5bd8ced48ea8dbd2b003@52.76.189.200:26656,ef472367307808b242a0d3f662d802431ed23063@175.41.186.255:26656,d3d2139a61c2a841545e78ff0e0cd03094a5197d@18.136.230.70:26656"# ; s#^(create_empty_blocks_interval[[:space:]]+=[[:space:]]+).*$#\1"5s"#' ~/.chain-maind/config/config.toml
   ```
+  
+ - Also remove the old persistent peers, in ~/.chain-maind/config/config.toml, please modify the configurations of `persistent_peers` by:
+ 
+  ```bash
+  $ sed -i.bak -E 's#^(persistent_peers[[:space:]]+=[[:space:]]+).*$#\1""#' ~/.chain-maind/config/config.toml
+  ```
 
 #### Step 3.5 (Optional) Configure `STATE-SYNC`
 


### PR DESCRIPTION
In Opensuse Leap 15.2 the chain would not start syncing until this change was performed. Not so sure whether this is actually needed, but IPs in the configuration file seemed to be old (from testnet-1).
In addition, deleting the file and fetching it new would start with empty persistent_peers, so I assume deleting them should not hurt.
Please review this PR as I'm a bit new to github.
PS: I believe indentation of my change is not fully OK, feel free to change it if needed.